### PR TITLE
FEAT: add a global community health PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Context
+
+> Why are you making this change?
+
+## Origin
+
+> What team/individual requested this change? Please link to a JIRA ticket or other documentation if applicable. If you identified this issue yourself please write "Me" (and still link to any additional context if it exists).
+
+## Summary of Changes
+
+> Provide a short description or bulleted list of changes made in this PR.
+
+## Test Plan
+
+> How have you tested this change, and what further testing will be done? What’s the riskiest part of this PR? How will you test and monitor that?
+
+## Documentation
+
+> Have you commented on parts of this PR that may be confusing to future readers who lack context? If this changes any workflows, have you updated the appropriate READMEs?

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->
+
+<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->
+
 ## Context
 
 > Why are you making this change?
@@ -8,12 +12,15 @@
 
 ## Summary of Changes
 
-> Provide a short description or bulleted list of changes made in this PR.
+<!-- Provide a short description or bulleted list of changes made in this PR. -->
 
 ## Test Plan
 
-> How have you tested this change, and what further testing will be done? What’s the riskiest part of this PR? How will you test and monitor that?
+<!-- How have you tested this change, and what further testing will be done? What’s the riskiest part of this PR? How will you test and monitor that? -->
 
 ## Documentation
 
-> Have you commented on parts of this PR that may be confusing to future readers who lack context? If this changes any workflows, have you updated the appropriate READMEs?
+<!-- This is a task list. To mark a task as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->
+
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)


### PR DESCRIPTION
https://github.com/opendoor-labs/code/pull/30375 added a PR template into that project's root directory to help raise the bar of PR quality in that repo, and also partially driven by a desire to improve audit-ability from the perspective of SOX. Discussion in that PR indicated aspirations of extending the PR template to other repos.

A DRY way of accomplishing this is to use community health files (https://docs.github.com/en/enterprise-cloud@latest/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file), which requires defining a `pull_request_template.md` in a _**public**_, super-special repository called `.github` (unfortunately I believe it must be public, it can't be just `internal`). 

Repositories owned by @opendoor-labs that do not specify a `pull_request_template.md` will inherit the one described in this PR (which is just a c/p from `code`). Repositories that do specify their own PR template will get the overridden version. As a result, this PR will add this PR template to N number of repos, which currently lack a template.