### PR TITLE
Change Documentation to Checklist and add item to check dependency PRs

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -16,11 +16,12 @@
 
 <!-- How have you tested this change, and what further testing will be done? What’s the riskiest part of this PR? How will you test and monitor that? -->
 
-## Documentation
+## Checklist
 
-<!-- This is a task list. To mark a task as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->
+<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->
 
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)
+- [ ] I have checked that other PRs this PR depends on have already been deployed.
 
 <!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

I once merged a PR where another PR it depends on was deployed to staging but not production, causing a SEV1. This gives us a reminder not to make that mistake again.

## Origin

https://opendoor.atlassian.net/jira/servicedesk/projects/PMS/queues/custom/706/PMS-871

## Summary of Changes

Change Documentation to Checklist
Add item to check dependency PRs

## Test Plan

N/A

## Documentation

N/A