### PR TITLE
CODEOWNERS: Replace @opendoor-labs/foundation with @opendoor-labs/devex

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/PULL_REQUEST_TEMPLATE.md @opendoor-labs/foundation
+/PULL_REQUEST_TEMPLATE.md @opendoor-labs/devex


### PR DESCRIPTION
## Summary

The `foundation` GitHub team was deleted as part of the 2026 engineering team consolidation (its child teams `devex` and `cloud-infra` were recreated independently). This PR updates the single CODEOWNERS reference.

## Changes

- `/PULL_REQUEST_TEMPLATE.md`: `@opendoor-labs/foundation` → `@opendoor-labs/devex`

## Test plan

- [ ] Verify `devex` team exists and has appropriate repo access
- [ ] Confirm no open PRs are blocked by the removed team reference


Made with [Cursor](https://cursor.com)